### PR TITLE
fix:weapp编译时自动配置页面声明

### DIFF
--- a/packages/mp_build_tools/lib/build_weapp.dart
+++ b/packages/mp_build_tools/lib/build_weapp.dart
@@ -12,12 +12,10 @@ Map? appJson;
 
 main(List<String> args) {
   print(I18n.building());
-  appJson = json.decode(
-    File(p.join('weapp', 'app.json')).readAsStringSync(),
-  ) as Map;
   _checkPubspec();
   _createBuildDir();
   miniProgramConfig = _fetchMiniProgramConfig();
+  appJson = _createAppJson();
   plugin_builder.main(args);
   _copyWeappSource();
   _createPages();
@@ -49,6 +47,21 @@ Map? _fetchMiniProgramConfig() {
       return json.decode(result.stdout);
     } catch (e) {}
   }
+  return null;
+}
+
+Map _createAppJson() {
+  final _appJson = json.decode(
+    File(p.join('weapp', 'app.json')).readAsStringSync(),
+  ) as Map;
+  final List pages = _appJson["pages"];
+  Map<dynamic, dynamic> pagesMap = miniProgramConfig!["pages"];
+  pagesMap.keys.toList().forEach((k) {
+    String page = k.split("/")[1];
+    if (!pages.contains(page)) pages.add(page);
+  });
+  _appJson["pages"] = pages;
+  return _appJson;
 }
 
 void _buildDartJS(List<String> args) {


### PR DESCRIPTION
在 `lib/weapp.config.dart` 中配置页面后进行打包，编译脚本未自动将额外声明的页面值注入到 app.json 中，导致配置不生效。
此修改会根据 `weapp.config.dart` 中的值自动为 `app.json` 添加对应声明。