### PR TITLE
weapp 编译时使用正则匹配修改当前模式

### DIFF
--- a/packages/mp_build_tools/lib/build_weapp.dart
+++ b/packages/mp_build_tools/lib/build_weapp.dart
@@ -91,7 +91,8 @@ void _buildDartJS(List<String> args) {
       """var \$__dart_deferred_initializers__ = self.\$__dart_deferred_initializers__;module.exports.main = (function dartProgram()""");
   File(p.join('build', 'main.dart.js')).writeAsStringSync(codeSource);
   var appSource = File(p.join('build', 'app.js')).readAsStringSync();
-  appSource = appSource.replaceAll("var dev = true;", "var dev = false;");
+  appSource = appSource.replaceAll(
+      RegExp(r"""var\sdev\s=\strue;?"""), "var dev = false;");
   File(p.join('build', 'app.js')).writeAsStringSync(appSource);
   final buildBundleResult = Process.runSync(
     'flutter',


### PR DESCRIPTION
调试微信小程序时需要手动修改 app.js 中的 ip ，此时由于编辑器内置的格式化规则可能导致一些预期外的修改（比如自动去掉了语句末尾的分号）。而编译脚本通过直接匹配 `var dev = true;` 语句进行替换。这时候会导致替换失败，编译出来的代码依旧被识别为 dev 模式，导致预览白屏。这里尝试使用正则表达式匹配语句来避免这一问题。